### PR TITLE
Update manifests

### DIFF
--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: cloudstack-csi-controller
       nodeSelector:
         kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - effect: NoExecute
           operator: Exists

--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -47,7 +47,7 @@ spec:
               mountPath: /etc/cloudstack-csi-driver
 
         - name: external-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.1
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -61,7 +61,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: external-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v4.3.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"

--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -61,7 +61,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: external-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.0.2
+          image: k8s.gcr.io/sig-storage/csi-attacher:v4.3.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"

--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -47,7 +47,7 @@ spec:
               mountPath: /etc/cloudstack-csi-driver
 
         - name: external-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.4
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.1
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"

--- a/deploy/k8s/node-daemonset.yaml
+++ b/deploy/k8s/node-daemonset.yaml
@@ -57,7 +57,7 @@ spec:
               mountPath: /etc/cloudstack-csi-driver
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.8.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"

--- a/deploy/k8s/node-daemonset.yaml
+++ b/deploy/k8s/node-daemonset.yaml
@@ -57,7 +57,7 @@ spec:
               mountPath: /etc/cloudstack-csi-driver
 
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.8.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
Update manifests with several changes:

- Change nodeSelector from master to control-plane
- Update CSI external provisioner to v3.3.1
- Update CSI external attacher to v4.3.0
- Update CSI node-driver-registrar to v2.8.0
- Switch to registry.k8s.io