### PR TITLE
feat: Set priorityClassName in deploy manifest, split setting in chart

### DIFF
--- a/charts/cloudstack-csi/templates/csi-controller-deploy.yaml
+++ b/charts/cloudstack-csi/templates/csi-controller-deploy.yaml
@@ -208,8 +208,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+    {{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cloudstack-csi/templates/csi-node-ds.yaml
+++ b/charts/cloudstack-csi/templates/csi-node-ds.yaml
@@ -174,8 +174,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+    {{- if .Values.node.priorityClassName }}
+      priorityClassName: {{ .Values.node.priorityClassName }}
     {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/cloudstack-csi/values.yaml
+++ b/charts/cloudstack-csi/values.yaml
@@ -66,6 +66,7 @@ controller:
       # maxSurge is the maximum number of pods that can be
       # created over the desired number of pods.
       maxSurge: 1
+  priorityClassName: ""
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 65532
@@ -118,7 +119,7 @@ node:
       hostPath:
         path: /etc/cacert
   dnsPolicy: ClusterFirstWithHostNet
-    
+  priorityClassName: ""
   podSecurityContext: {}
  
   securityContext: {}
@@ -207,8 +208,6 @@ secret:
       api-key: ""
       secret-key: ""
   hostMount: false
-
-priorityClassName: ""
 
 imagePullSecrets: []
 # - name: my-imagepull-secret

--- a/deploy/k8s/controller-deployment.yaml
+++ b/deploy/k8s/controller-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cloudstack-csi-controller
   namespace: kube-system
 spec:
-  replicas: 3
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -21,6 +21,7 @@ spec:
         app.kubernetes.io/name: cloudstack-csi-controller
         app.kubernetes.io/part-of: cloudstack-csi-driver
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: cloudstack-csi-controller
       nodeSelector:
         kubernetes.io/os: linux

--- a/deploy/k8s/node-daemonset.yaml
+++ b/deploy/k8s/node-daemonset.yaml
@@ -15,6 +15,7 @@ spec:
         app.kubernetes.io/name: cloudstack-csi-node
         app.kubernetes.io/part-of: cloudstack-csi-driver
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
@@ -25,7 +26,7 @@ spec:
 
       containers:
         - name: cloudstack-csi-node
-          image: cloudstack-csi-driver
+          image: ghcr.io/leaseweb/cloudstack-csi-driver:master
           imagePullPolicy: Always
           args:
             - "-endpoint=$(CSI_ENDPOINT)"
@@ -55,8 +56,6 @@ spec:
               mountPropagation: Bidirectional
             - name: device-dir
               mountPath: /dev
-            - name: cloud-init-dir
-              mountPath: /run/cloud-init/
             - name: cloudstack-conf
               mountPath: /etc/cloudstack-csi-driver
           ports:
@@ -131,10 +130,6 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
-            type: Directory
-        - name: cloud-init-dir
-          hostPath:
-            path: /run/cloud-init/
             type: Directory
         - name: cloudstack-conf
           secret:

--- a/deploy/k8s/node-daemonset.yaml
+++ b/deploy/k8s/node-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
 
       containers:
         - name: cloudstack-csi-node
-          image: ghcr.io/leaseweb/cloudstack-csi-driver:master
+          image: cloudstack-csi-driver
           imagePullPolicy: Always
           args:
             - "-endpoint=$(CSI_ENDPOINT)"
@@ -56,6 +56,8 @@ spec:
               mountPropagation: Bidirectional
             - name: device-dir
               mountPath: /dev
+            - name: cloud-init-dir
+              mountPath: /run/cloud-init/
             - name: cloudstack-conf
               mountPath: /etc/cloudstack-csi-driver
           ports:
@@ -130,6 +132,10 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        - name: cloud-init-dir
+          hostPath:
+            path: /run/cloud-init/
             type: Directory
         - name: cloudstack-conf
           secret:


### PR DESCRIPTION
Set priorityClassName in the simple deploy manifest.

Move priorityClassName from a top-level value to a controller/node specific value, so the controller can be system-cluster-critical and the node ds system-node-critical.