### PR TITLE
Added allowedtopologies to storage class

### DIFF
--- a/cmd/cloudstack-csi-sc-syncer/README.md
+++ b/cmd/cloudstack-csi-sc-syncer/README.md
@@ -89,14 +89,26 @@ spec:
           args:
             - "-cloudstackconfig=/etc/cloudstack-csi-driver/cloud-config"
             - "-kubeconfig=-"
+             - "-nodeName=$(NODE_NAME)"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - name: cloudstack-conf
               mountPath: /etc/cloudstack-csi-driver
+            - name: cloud-init-dir
+              mountPath: /run/cloud-init/
       restartPolicy: Never
       volumes:
         - name: cloudstack-conf
           secret:
             secretName: cloudstack-secret
+        - name: cloud-init-dir
+          hostPath:
+            path: /run/cloud-init/
+            type: Directory
 E0F
 ```
 

--- a/cmd/cloudstack-csi-sc-syncer/main.go
+++ b/cmd/cloudstack-csi-sc-syncer/main.go
@@ -23,7 +23,9 @@ var (
 	deleteUnused     = flag.Bool("delete", false, "Delete")
 	volumeExpansion  = flag.Bool("volumeExpansion", false, "VolumeExpansion")
 	showVersion      = flag.Bool("version", false, "Show version")
-
+	nodeName         = flag.String("nodeName", "", "Node name")
+	addAllowedTopology = flag.Bool("addAllowedTopology", false, "Add allowed topology to storageclass")
+	
 	// Version is set by the build process.
 	version = ""
 )
@@ -46,6 +48,8 @@ func main() {
 		NamePrefix:       *namePrefix,
 		Delete:           *deleteUnused,
 		VolumeExpansion:  *volumeExpansion,
+		NodeName:         *nodeName,
+		AddAllowedTopology: *addAllowedTopology,
 	})
 	if err != nil {
 		log.Fatalf("Error: %v", err)


### PR DESCRIPTION
Problem:
   In a hybrid environment where there are some none cloudstack nodes exists, the persistent volume can be scheduled on none cloudstack nodes, this will cause persistent volume attatchment failure if the storage offering only exists in cloudstack. 

Fix:
  The fix is to add allowedtopologies entry to the cloudstack storage class so that the persistent volumes can only be scheduled on the cloudstack nodes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
