### PR TITLE
Fix volume expansion

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -24,7 +24,7 @@ type Cloud interface {
 	DeleteVolume(ctx context.Context, id string) error
 	AttachVolume(ctx context.Context, volumeID, vmID string) (string, error)
 	DetachVolume(ctx context.Context, volumeID string) error
-	ExpandVolume(ctx context.Context, cs *ControllerService, volumeID string, newSizeInGB int64) error
+	ExpandVolume(ctx context.Context, volume *Volume, volumeID string, newSizeInGB int64) error
 }
 
 // Volume represents a CloudStack volume.

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -24,7 +24,7 @@ type Cloud interface {
 	DeleteVolume(ctx context.Context, id string) error
 	AttachVolume(ctx context.Context, volumeID, vmID string) (string, error)
 	DetachVolume(ctx context.Context, volumeID string) error
-	ExpandVolume(ctx context.Context, volumeID string, newSizeInGB int64) error
+	ExpandVolume(ctx context.Context, cs *ControllerService, volumeID string, newSizeInGB int64) error
 }
 
 // Volume represents a CloudStack volume.

--- a/pkg/cloud/fake/fake.go
+++ b/pkg/cloud/fake/fake.go
@@ -131,7 +131,7 @@ func (f *fakeConnector) DetachVolume(_ context.Context, volumeID string) error {
 	return cloud.ErrNotFound
 }
 
-func (f *fakeConnector) ExpandVolume(_ context.Context, cs *ControllerService, volumeID string, newSizeInGB int64) error {
+func (f *fakeConnector) ExpandVolume(_ context.Context, volume *Volume, volumeID string, newSizeInGB int64) error {
 	if vol, ok := f.volumesByID[volumeID]; ok {
 		newSizeInBytes := newSizeInGB * 1024 * 1024 * 1024
 		if newSizeInBytes > vol.Size {

--- a/pkg/cloud/fake/fake.go
+++ b/pkg/cloud/fake/fake.go
@@ -131,7 +131,7 @@ func (f *fakeConnector) DetachVolume(_ context.Context, volumeID string) error {
 	return cloud.ErrNotFound
 }
 
-func (f *fakeConnector) ExpandVolume(_ context.Context, volumeID string, newSizeInGB int64) error {
+func (f *fakeConnector) ExpandVolume(_ context.Context, cs *ControllerService, volumeID string, newSizeInGB int64) error {
 	if vol, ok := f.volumesByID[volumeID]; ok {
 		newSizeInBytes := newSizeInGB * 1024 * 1024 * 1024
 		if newSizeInBytes > vol.Size {

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -505,7 +505,7 @@ func (cs *ControllerService) ControllerExpandVolume(ctx context.Context, req *cs
 		return nil, status.Error(codes.OutOfRange, "Volume size exceeds the limit specified")
 	}
 
-	_, err := cs.connector.GetVolumeByID(ctx, volumeID)
+	volume, err := cs.connector.GetVolumeByID(ctx, volumeID)
 	if err != nil {
 		if errors.Is(err, cloud.ErrNotFound) {
 			return nil, status.Errorf(codes.NotFound, "Volume %v not found", volumeID)
@@ -522,7 +522,8 @@ func (cs *ControllerService) ControllerExpandVolume(ctx context.Context, req *cs
 	}
 	defer cs.operationLocks.ReleaseExpandLock(volumeID)
 
-	err = cs.connector.ExpandVolume(ctx, volumeID, volSizeGB)
+	err = cs.connector.ExpandVolume(ctx, cs, volumeID, volSizeGB)
+	
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not resize volume %q to size %v: %v", volumeID, volSizeGB, err)
 	}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -522,7 +522,7 @@ func (cs *ControllerService) ControllerExpandVolume(ctx context.Context, req *cs
 	}
 	defer cs.operationLocks.ReleaseExpandLock(volumeID)
 
-	err = cs.connector.ExpandVolume(ctx, cs, volumeID, volSizeGB)
+	err = cs.connector.ExpandVolume(ctx, volume, volumeID, volSizeGB)
 	
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not resize volume %q to size %v: %v", volumeID, volSizeGB, err)


### PR DESCRIPTION
Problem: 
   Volume expansion function called c.volume.getVolumebyId() that results in no volume found, this caused volume expansion failure. The reason is to find volume, cloudstack API require projectID. 

Fix:
  The fix is to use the volume returned by the native getVolumebyId() function that passed the projectID to the cloudstack API call.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
