### PR TITLE
Bump sidecar containers & chart version for release v0.10.0

### DIFF
--- a/charts/cloudstack-csi/Chart.yaml
+++ b/charts/cloudstack-csi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cloudstack-csi
 description: A Helm chart for CloudStack CSI driver
 type: application
-version: 2.3.1
-appVersion: 0.9.1
+version: 2.4.0
+appVersion: 0.10.0
 sources:
   - https://github.com/Leaseweb/cloudstack-csi-driver
 keywords:

--- a/charts/cloudstack-csi/values.yaml
+++ b/charts/cloudstack-csi/values.yaml
@@ -25,7 +25,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: registry.k8s.io/sig-storage/csi-provisioner
-      tag: "v5.0.2"
+      tag: "v5.2.0"
     logLevel: 2
     # Feature gates to enable
     featureGates: "Topology=true"
@@ -52,7 +52,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: registry.k8s.io/sig-storage/csi-attacher
-      tag: "v4.6.1"
+      tag: "v4.8.1"
     # Tune leader lease election for csi-attacher.
     # Leader election is on by default.
     leaderElection:
@@ -76,7 +76,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: registry.k8s.io/sig-storage/livenessprobe
-      tag: "v2.13.1"
+      tag: "v2.15.0"
     # Extra arguments passed to livenessprobe.
     extraArgs: []
     resources: {}
@@ -88,7 +88,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: registry.k8s.io/sig-storage/csi-resizer
-      tag: "v1.11.2"
+      tag: "v1.13.2"
     # Tune leader lease election for csi-resizer.
     # Leader election is on by default.
     leaderElection:
@@ -113,7 +113,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-      tag: "v2.11.1"
+      tag: "v2.13.0"
     logLevel: 2
     # Extra arguments passed to node-driver-registrar.
     extraArgs: []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR updates the sidecar container version for K8s 1.32 in the Helm chart, and bumps the minor version of the Helm chart for release v0.10.0

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
